### PR TITLE
Add CRUD endpoints for offering (service) management

### DIFF
--- a/requests/offering-requests.http
+++ b/requests/offering-requests.http
@@ -1,0 +1,52 @@
+###
+GET http://localhost:8080/offerings
+###
+POST http://localhost:8080/offerings
+Content-Type: application/json
+
+{
+  "name": "Catering",
+  "price": 6000,
+  "type": "CATERING",
+  "options": [],
+  "offeringAreas": [],
+  "availabilitySlots": []
+}
+
+###
+PUT http://localhost:8080/offerings/2
+Content-Type: application/json
+
+{
+  "name": "cat",
+  "price": 9000,
+  "type": "PHOTOGRAPHY",
+  "options": [],
+  "offeringAreas": [],
+  "availabilitySlots": []
+}
+
+###
+DELETE http://localhost:8080/offerings/1
+
+###
+GET http://localhost:8080/offerings/2/options
+###
+POST http://localhost:8080/offerings/2/options
+Content-Type: application/json
+
+{
+  "name": "Camera",
+  "price": 600
+}
+###
+###
+GET http://localhost:8080/offerings/2/availability
+###
+POST http://localhost:8080/offerings/2/availability
+Content-Type: application/json
+
+{
+  "startTime": "2025-12-25T18:00:00",
+  "endTime": "2026-12-25T18:00:00"
+}

--- a/src/main/java/com/eventsystem/controller/OfferingController.java
+++ b/src/main/java/com/eventsystem/controller/OfferingController.java
@@ -1,0 +1,63 @@
+package com.eventsystem.controller;
+
+import com.eventsystem.dto.OfferingDto;
+import com.eventsystem.model.Offering;
+import com.eventsystem.service.OfferingService;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/offerings")
+public class OfferingController {
+    private final OfferingService offeringService;
+
+    public OfferingController(OfferingService offeringService) {
+        this.offeringService = offeringService;
+    }
+
+    @GetMapping
+    public List<OfferingDto> getAllOfferings() {
+        return offeringService.getAllOfferings();
+    }
+
+    @PostMapping
+    public OfferingDto createOffering(@RequestBody Offering offering) {
+        return offeringService.createOffering(offering);
+    }
+
+    @PutMapping("/{id}")
+    public OfferingDto updateOffering(@PathVariable Long id, @RequestBody Offering offering) {
+        return offeringService.updateOffering(id, offering);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteOffering(@PathVariable Long id) {
+        offeringService.deleteOffering(id);
+    }
+
+    @GetMapping("/{id}/options")
+    public List<Offering.Option> getAllOptions(@PathVariable Long id) {
+        return offeringService.getAllOptions(id);
+    }
+
+    @PostMapping("/{id}/options")
+    public OfferingDto addOption(
+            @PathVariable Long id,
+            @RequestBody Offering.Option option) {
+        return offeringService.addOption(id, option);
+    }
+
+    @GetMapping("/{id}/availability")
+    public List<Offering.AvailabilitySlot> getAllAvailabilitySlot(@PathVariable Long id) {
+        return offeringService.getAllAvailabilitySlot(id);
+    }
+
+    @PostMapping("/{id}/availability")
+    public OfferingDto addAvailabilitySlot(
+            @PathVariable Long id,
+            @RequestBody Offering.AvailabilitySlot availabilitySlot) {
+        return offeringService.addAvailabilitySlot(id, availabilitySlot.getStartTime(), availabilitySlot.getEndTime());
+    }
+}

--- a/src/main/java/com/eventsystem/dto/OfferingDto.java
+++ b/src/main/java/com/eventsystem/dto/OfferingDto.java
@@ -1,0 +1,18 @@
+package com.eventsystem.dto;
+
+import com.eventsystem.model.Offering;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class OfferingDto {
+    private String name;
+    private Integer price;
+    private Offering.OfferingType type;
+    private List<Offering.Option> options;
+    private List<String> offeringAreas;
+    private List<Offering.AvailabilitySlot> availabilitySlots;
+}

--- a/src/main/java/com/eventsystem/mapper/OfferingMapper.java
+++ b/src/main/java/com/eventsystem/mapper/OfferingMapper.java
@@ -1,0 +1,30 @@
+package com.eventsystem.mapper;
+
+import com.eventsystem.dto.OfferingDto;
+import com.eventsystem.model.Offering;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OfferingMapper {
+    public OfferingDto toDto(Offering offering) {
+        return new OfferingDto(
+                offering.getName(),
+                offering.getPrice(),
+                offering.getType(),
+                offering.getOptions(),
+                offering.getOfferingAreas(),
+                offering.getAvailabilitySlots()
+        );
+    }
+
+    public Offering toEntity(OfferingDto offeringDto) {
+        return new Offering(
+                offeringDto.getName(),
+                offeringDto.getPrice(),
+                offeringDto.getType(),
+                offeringDto.getOptions(),
+                offeringDto.getOfferingAreas(),
+                offeringDto.getAvailabilitySlots()
+        );
+    }
+}

--- a/src/main/java/com/eventsystem/model/Offering.java
+++ b/src/main/java/com/eventsystem/model/Offering.java
@@ -1,0 +1,103 @@
+package com.eventsystem.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Entity
+@NoArgsConstructor
+@Table(name = "offerings")
+public class Offering {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private Integer price;
+
+    @Enumerated(EnumType.STRING)
+    private OfferingType type;
+
+    @ElementCollection
+    @CollectionTable(name = "offering_options", joinColumns = @JoinColumn(name = "offering_id"))
+    private List<Option> options;
+
+    @ElementCollection
+    @CollectionTable(name = "offering_areas", joinColumns = @JoinColumn(name = "offering_id"))
+    @Column(name = "location")
+    private List<String> offeringAreas;
+
+    @ElementCollection
+    @CollectionTable(name = "offering_availability_slots", joinColumns = @JoinColumn(name = "offering_id"))
+    private List<AvailabilitySlot> availabilitySlots;
+
+    public Offering(String name, Integer price, OfferingType type, List<Option> options, List<String> offeringAreas, List<AvailabilitySlot> availabilitySlots) {
+        this.name = name;
+        this.price = price;
+        this.type = type;
+        this.options = options;
+        this.offeringAreas = offeringAreas;
+        this.availabilitySlots = availabilitySlots;
+    }
+
+    public enum OfferingType {
+        CATERING, DECORATION, AUDIO_VISUAL_EQUIPMENT,
+        PHOTOGRAPHY, FURNITURE_RENTAL, SECURITY
+    }
+
+    @Data
+    @Embeddable
+    public static class Option {
+        private String name;
+        private Integer price;
+    }
+
+    @Data
+    @Embeddable
+    @NoArgsConstructor
+    public static class AvailabilitySlot {
+        @JsonProperty("startTime")
+        private LocalDateTime startTime;
+        @JsonProperty("endTime")
+        private LocalDateTime endTime;
+
+        public AvailabilitySlot(LocalDateTime startTime, LocalDateTime endTime) {
+            this.startTime = startTime;
+            this.endTime = endTime;
+        }
+    }
+
+    public boolean isAvailableAt(LocalDateTime dateTime) {
+        return availabilitySlots.stream()
+                .anyMatch(slot ->
+                        !dateTime.isBefore(slot.getStartTime()) &&
+                                !dateTime.isAfter(slot.getEndTime()));
+    }
+
+    public void addOfferingArea(String location) {
+        if (offeringAreas == null) {
+            offeringAreas = new ArrayList<>();
+        }
+        offeringAreas.add(location.trim().toLowerCase());
+    }
+
+    public void addOption(Option option) {
+        if (options == null) {
+            options = new ArrayList<>();
+        }
+        options.add(option);
+    }
+
+    public void addAvailabilitySlot(AvailabilitySlot availabilitySlot){
+        if (availabilitySlots == null) {
+            availabilitySlots = new ArrayList<>();
+        }
+        availabilitySlots.add(availabilitySlot);
+    }
+}

--- a/src/main/java/com/eventsystem/repository/OfferingRepository.java
+++ b/src/main/java/com/eventsystem/repository/OfferingRepository.java
@@ -1,0 +1,7 @@
+package com.eventsystem.repository;
+
+import com.eventsystem.model.Offering;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OfferingRepository extends JpaRepository<Offering, Long> {
+}

--- a/src/main/java/com/eventsystem/service/OfferingService.java
+++ b/src/main/java/com/eventsystem/service/OfferingService.java
@@ -1,0 +1,75 @@
+package com.eventsystem.service;
+
+import com.eventsystem.dto.OfferingDto;
+import com.eventsystem.mapper.OfferingMapper;
+import com.eventsystem.model.Offering;
+import com.eventsystem.repository.OfferingRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+public class OfferingService {
+    private final OfferingRepository offeringRepository;
+    private final OfferingMapper offeringMapper;
+
+    public OfferingService(OfferingRepository offeringRepository, OfferingMapper offeringMapper) {
+        this.offeringRepository = offeringRepository;
+        this.offeringMapper = offeringMapper;
+    }
+
+    public List<OfferingDto> getAllOfferings() {
+        return offeringRepository
+                .findAll()
+                .stream()
+                .map(offeringMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public OfferingDto createOffering(Offering offering) {
+        Offering o = offeringRepository.save(offering);
+        return offeringMapper.toDto(o);
+    }
+
+    public OfferingDto updateOffering(Long id, Offering newOffering) {
+        Offering o = offeringRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Offering not found"));
+        o.setName(newOffering.getName());
+        o.setPrice(newOffering.getPrice());
+        o.setType(newOffering.getType());
+        o.setOptions(newOffering.getOptions());
+        o.setOfferingAreas(newOffering.getOfferingAreas());
+        o.setAvailabilitySlots(newOffering.getAvailabilitySlots());
+        return offeringMapper.toDto(o);
+    }
+
+    public void deleteOffering(Long id) {
+        offeringRepository.deleteById(id);
+    }
+
+    public List<Offering.Option> getAllOptions(Long id) {
+        Offering offering = offeringRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Offering not found"));
+        return offering.getOptions();
+    }
+
+    public OfferingDto addOption(Long id, Offering.Option option) {
+        Offering offering = offeringRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Offering not found"));
+        offering.addOption(option);
+        offeringRepository.save(offering);
+        return offeringMapper.toDto(offering);
+    }
+
+    public List<Offering.AvailabilitySlot> getAllAvailabilitySlot(Long id) {
+        Offering offering = offeringRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Offering not found"));
+        return offering.getAvailabilitySlots();
+    }
+
+    public OfferingDto addAvailabilitySlot(Long id, LocalDateTime startTime, LocalDateTime endTime) {
+        Offering offering = offeringRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Offering not found"));
+        offering.addAvailabilitySlot(new Offering.AvailabilitySlot(startTime, endTime));
+        offeringRepository.save(offering);
+        return offeringMapper.toDto(offering);
+    }
+}


### PR DESCRIPTION
New endpoints implemented:

`GET /offerings` - Get all offerings  
`POST /offerings` - Create a new offering  
`PUT /offerings/{id}` - Update an offering  
`DELETE /offerings/{id}` - Delete an offering  

`GET /offerings/{id}/options` - Get all options for an offering  
`POST /offerings/{id}/options` - Add an option to an offering  

`GET /offerings/{id}/availability` - Get all availability slots for an offering  
`POST /offerings/{id}/availability` - Add an availability slot to an offering
